### PR TITLE
Development

### DIFF
--- a/app/Filament/Resources/Projects/Pages/CreateProject.php
+++ b/app/Filament/Resources/Projects/Pages/CreateProject.php
@@ -8,4 +8,11 @@ use Filament\Resources\Pages\CreateRecord;
 class CreateProject extends CreateRecord
 {
     protected static string $resource = ProjectResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['owner_id'] = auth()->id();
+
+        return $data;
+    }
 }

--- a/app/Filament/Resources/Projects/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/MembersRelationManager.php
@@ -2,6 +2,10 @@
 
 namespace App\Filament\Resources\Projects\RelationManagers;
 
+use Filament\Actions\AttachAction;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
@@ -56,12 +60,12 @@ class MembersRelationManager extends RelationManager
                 //
             ])
             ->recordActions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                EditAction::make(),
+                DeleteAction::make(),
             ])
             ->toolbarActions([
-                Tables\Actions\CreateAction::make(),
-                Tables\Actions\AttachAction::make()
+                CreateAction::make(),
+                AttachAction::make()
                     ->recordSelectOptionsQuery(fn ($query) => $query->whereNotIn('id', $this->ownerRecord->members->pluck('id'))),
             ]);
     }

--- a/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
@@ -3,6 +3,9 @@
 namespace App\Filament\Resources\Projects\RelationManagers;
 
 use App\Models\User;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
@@ -94,11 +97,11 @@ class TasksRelationManager extends RelationManager
                     ->relationship('assignedTo', 'name'),
             ])
             ->recordActions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                EditAction::make(),
+                DeleteAction::make(),
             ])
             ->toolbarActions([
-                Tables\Actions\CreateAction::make(),
+                CreateAction::make(),
             ])
             ->defaultSort('order', 'asc');
     }

--- a/app/Filament/Resources/Tasks/Pages/CreateTask.php
+++ b/app/Filament/Resources/Tasks/Pages/CreateTask.php
@@ -8,4 +8,11 @@ use Filament\Resources\Pages\CreateRecord;
 class CreateTask extends CreateRecord
 {
     protected static string $resource = TaskResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['created_by'] = auth()->id();
+
+        return $data;
+    }
 }

--- a/app/Filament/Resources/Tasks/RelationManagers/CommentsRelationManager.php
+++ b/app/Filament/Resources/Tasks/RelationManagers/CommentsRelationManager.php
@@ -2,6 +2,9 @@
 
 namespace App\Filament\Resources\Tasks\RelationManagers;
 
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
@@ -49,11 +52,11 @@ class CommentsRelationManager extends RelationManager
                 //
             ])
             ->recordActions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                EditAction::make(),
+                DeleteAction::make(),
             ])
             ->toolbarActions([
-                Tables\Actions\CreateAction::make(),
+                CreateAction::make(),
             ])
             ->defaultSort('created_at', 'desc');
     }


### PR DESCRIPTION
This pull request introduces improvements to how ownership and user attribution are handled during creation of projects and tasks, and refactors the usage of Filament action classes for better code clarity and maintainability. The main changes include automatically setting the owner or creator ID when a new project or task is created, and replacing the verbose `Tables\Actions` references with direct imports of the relevant Filament action classes.

**Ownership and Attribution Enhancements:**
* Automatically assign the authenticated user as the owner when creating a new project in `CreateProject` by setting `owner_id` in the `mutateFormDataBeforeCreate` method.
* Automatically assign the authenticated user as the creator when creating a new task in `CreateTask` by setting `created_by` in the `mutateFormDataBeforeCreate` method.

**Refactoring Filament Action Classes:**
* Replaced `Tables\Actions\EditAction`, `Tables\Actions\DeleteAction`, `Tables\Actions\CreateAction`, and `Tables\Actions\AttachAction` with direct imports and usage of `EditAction`, `DeleteAction`, `CreateAction`, and `AttachAction` in `MembersRelationManager`, `TasksRelationManager`, and `CommentsRelationManager`. This improves code readability and reduces verbosity. [[1]](diffhunk://#diff-b59622d33a9bef6d3f79f6b14ec5a21bc61319dadcd57b8b248856d094b26b7aR5-R8) [[2]](diffhunk://#diff-b59622d33a9bef6d3f79f6b14ec5a21bc61319dadcd57b8b248856d094b26b7aL59-R68) [[3]](diffhunk://#diff-6429eba6e251155e2043397d446f5f01cb5381023c3910963516dd68dfa4e930R6-R8) [[4]](diffhunk://#diff-6429eba6e251155e2043397d446f5f01cb5381023c3910963516dd68dfa4e930L97-R104) [[5]](diffhunk://#diff-cdb8e56483413fd846295b8ea5132349432541d9609b8b8e0a833d83cbb38f08R5-R7) [[6]](diffhunk://#diff-cdb8e56483413fd846295b8ea5132349432541d9609b8b8e0a833d83cbb38f08L52-R59)