### PR TITLE
feat: set max content width to full for admin panel

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -10,6 +10,7 @@ use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\Support\Enums\Width;
 use Filament\Widgets\AccountWidget;
 use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -32,6 +33,7 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Amber,
             ])
+            ->maxContentWidth(Width::Full)
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\Filament\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\Filament\Pages')
             ->pages([


### PR DESCRIPTION
## Summary
- Set `maxContentWidth` to `Width::Full` in AdminPanelProvider to utilize full viewport width

## Changes
- Added `use Filament\Support\Enums\Width` import
- Configured panel with `->maxContentWidth(Width::Full)`

## Test plan
- [x] Admin panel displays at full width
- [x] No layout issues on different screen sizes
- [x] Existing pages and resources render correctly