### PR TITLE
fix: use custom index name to comply with MariaDB 64-char identifier limit

### DIFF
--- a/database/migrations/2026_01_22_062230_create_documentables_table.php
+++ b/database/migrations/2026_01_22_062230_create_documentables_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->morphs('documentable'); // entity_type, entity_id
             $table->timestamps();
 
-            $table->index(['document_id', 'documentable_type', 'documentable_id']);
+            $table->index(['document_id', 'documentable_type', 'documentable_id'], 'docables_doc_type_id_index');
         });
     }
 


### PR DESCRIPTION
## Summary
- Fixed migration failure on MariaDB due to auto-generated index name exceeding 64-character identifier limit
- Changed composite index name from auto-generated `documentables_document_id_documentable_type_documentable_id_index` (65 chars) to custom `docables_doc_type_id_index` (28 chars)

## Fixes
Fixes #16

## Test plan
- [x] Migration runs successfully on MariaDB without identifier length errors
- [x] Migration remains compatible with MySQL