### PR TITLE
fix: improve Docker build with PHP 8.4, proper startup script, and migration detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,18 @@ FROM composer:2.8 AS builder
 
 WORKDIR /app
 
-# Install PHP extensions required for Laravel
-RUN docker-php-ext-install pdo pdo_sqlite
+# Install Node.js and npm for building assets
+# composer:2.8 is Alpine-based
+RUN apk add --no-cache nodejs npm
+
+# Install PHP extensions required for Laravel and Filament
+# Need sqlite-dev for building pdo_sqlite
+# Also need icu-dev for intl extension required by Filament
+RUN apk add --no-cache \
+    sqlite-dev \
+    icu-dev \
+    && docker-php-ext-install pdo pdo_sqlite intl \
+    && rm -rf /var/cache/apk/*
 
 # Copy Composer files
 COPY composer.json composer.lock ./
@@ -29,33 +39,44 @@ COPY . .
 RUN npm install \
     && npm run build
 
-# Clear and cache configs
-RUN php artisan config:cache \
-    && php artisan route:cache \
-    && php artisan view:cache
+# Create .env from .env.example and generate APP key
+RUN cp .env.example .env \
+    && php -r "echo 'APP_KEY=base64:' . base64_encode(random_bytes(32)) . PHP_EOL;" > /tmp/key.txt \
+    && grep -v "^APP_KEY=" .env > /tmp/.env.tmp \
+    && cat /tmp/key.txt >> /tmp/.env.tmp \
+    && mv /tmp/.env.tmp .env
+
+# Clear bootstrap cache (will be regenerated at runtime)
+RUN rm -rf bootstrap/cache/*.php
 
 # ===============================================
 # Stage 2: Production
 # Slim image with only production dependencies
 # ===============================================
-FROM php:8.2-fpm-alpine
+FROM php:8.4-fpm-alpine
 
 # Install required PHP extensions
 RUN apk add --no-cache \
     curl \
     nginx \
     sqlite \
+    sqlite-dev \
     libpng-dev \
     libzip-dev \
     zip \
+    libjpeg-turbo-dev \
+    freetype-dev \
+    icu-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install \
         pdo \
         pdo_sqlite \
+        intl \
         gd \
         zip \
         bcmath \
-        opcache
+        opcache \
+    && rm -rf /var/cache/apk/*
 
 # Create www-data user and set permissions
 RUN mkdir -p /var/www/html \
@@ -77,11 +98,15 @@ COPY docker/nginx/default.conf /etc/nginx/http.d/default.conf
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
+# Copy startup script
+COPY docker/start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
+
 # Expose port 80 for HTTP
 EXPOSE 80
 
 # Set entrypoint
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-# Start PHP-FPM and Nginx
-CMD ["php-fpm", "-D", "&&", "nginx", "-g", "daemon off;"]
+# Start using startup script
+CMD ["/usr/local/bin/start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     container_name: filament-pm-app
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "8083:80"
     environment:
       - APP_ENV=production
       - APP_DEBUG=false

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -34,15 +34,12 @@ if [ -z "$DB_CONNECTION" ] || [ "$DB_CONNECTION" = "sqlite" ]; then
 
     echo "🔧 Using SQLite: database/database.sqlite"
 
-    # Check if database is empty (no migrations table)
-    TABLE_COUNT=$(php artisan db:table --connection=sqlite 2>/dev/null || echo "0")
-
-    # Run migrations if database is empty
-    if [ "$TABLE_COUNT" = "0" ]; then
+    # Check if migrations table exists using sqlite3 command
+    if sqlite3 /var/www/html/database/database.sqlite "SELECT name FROM sqlite_master WHERE type='table' AND name='migrations';" 2>/dev/null | grep -q migrations; then
+        echo "✅ Database already migrated, skipping..."
+    else
         echo "🚀 Running database migrations..."
         php artisan migrate --force
-    else
-        echo "✅ Database already migrated, skipping..."
     fi
 else
     echo "ℹ️  DB_CONNECTION is set to '$DB_CONNECTION' - skipping auto-migration"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Start PHP-FPM in background
+php-fpm -D
+
+# Start Nginx in foreground
+nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- Upgrade from PHP 8.2 to PHP 8.4 in production Docker image
- Add missing PHP intl extension required by Filament
- Add separate startup script (docker/start.sh) for proper process management
- Fix migration detection logic using sqlite3 command
- Change exposed port from 8080 to 8083 to avoid conflicts

## Changes Made

### Dockerfile
- Upgraded production stage from `php:8.2-fpm-alpine` to `php:8.4-fpm-alpine`
- Added `intl` PHP extension (required by Filament)
- Added proper startup script for PHP-FPM and Nginx management
- Added APP_KEY generation during build
- Clear bootstrap cache before runtime

### docker/start.sh (new)
- Separate startup script for proper process management
- Starts PHP-FPM in background and Nginx in foreground

### docker/docker-entrypoint.sh
- Fixed migration detection using `sqlite3` command instead of `db:table`
- More reliable database migration check

### docker-compose.yml
- Changed exposed port from 8080 to 8083

## Test plan
- [ ] Build Docker image: `docker build -t filament-pm .`
- [ ] Run container: `docker-compose up`
- [ ] Verify application loads on http://localhost:8083
- [ ] Verify migrations run automatically on first start
- [ ] Verify subsequent starts skip migrations