### PR TITLE
fix: configure trust proxies for reverse proxy HTTPS support

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -11,7 +12,16 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        // Trust proxies when running behind a load balancer or reverse proxy
+        // (e.g., nginx, Caddy, Cloudflare, AWS ALB)
+        $middleware->trustProxies(
+            at: env('TRUSTED_PROXIES', '*'),
+            headers: Request::HEADER_X_FORWARDED_FOR |
+                Request::HEADER_X_FORWARDED_HOST |
+                Request::HEADER_X_FORWARDED_PORT |
+                Request::HEADER_X_FORWARDED_PROTO |
+                Request::HEADER_X_FORWARDED_AWS_ELB
+        );
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -31,6 +31,12 @@ server {
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
         fastcgi_hide_header X-Powered-By;
+
+        # Proxy headers for proper HTTPS detection behind reverse proxy
+        fastcgi_param HTTP_X_FORWARDED_PROTO $http_x_forwarded_proto if_not_empty;
+        fastcgi_param HTTP_X_FORWARDED_HOST $http_x_forwarded_host if_not_empty;
+        fastcgi_param HTTP_X_FORWARDED_PORT $http_x_forwarded_port if_not_empty;
+        fastcgi_param HTTP_X_FORWARDED_FOR $http_x_forwarded_for if_not_empty;
     }
 
     # Static files caching


### PR DESCRIPTION
## Summary
- Fixes mixed HTTPS/HTTP errors when Laravel is deployed behind a reverse proxy (nginx, Caddy, Cloudflare, AWS ALB)
- Configures Laravel to trust `X-Forwarded-*` headers from reverse proxies
- Updates Docker nginx configuration to properly pass proxy headers to PHP-FPM

## Problem
When running Filament PM behind a reverse proxy that terminates SSL/TLS, Laravel was generating HTTP URLs instead of HTTPS URLs because it didn't know the original request was secure. This caused:
- Mixed content warnings in browsers
- Broken asset links
- Incorrect form action URLs
- API endpoint errors

## Solution
Following Laravel 12's documentation for [Configuring Trusted Proxies](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies):

1. **bootstrap/app.php**: Added `trustProxies()` middleware configuration
   - Trusts all proxies by default (configurable via `TRUSTED_PROXIES` env var)
   - Trusts all standard X-Forwarded headers including `X-Forwarded-Proto` which is critical for HTTPS detection

2. **docker/nginx/default.conf**: Added fastcgi parameters to pass X-Forwarded headers to PHP-FPM

## Configuration
The fix uses `TRUSTED_PROXIES='*'` by default (trusts all proxies). For production, you can set specific proxy IPs in `.env`:
```env
TRUSTED_PROXIES=192.168.1.1,10.0.0.0/8
```

## Test Plan
- [ ] Deploy behind nginx reverse proxy with HTTPS
- [ ] Verify all asset URLs use HTTPS
- [ ] Verify form actions use HTTPS
- [ ] Verify no mixed content warnings in browser console
- [ ] Test with Cloudflare (if applicable)
- [ ] Test with AWS ALB (if applicable)

Fixes #28