### PR TITLE
fix: resolve created_by field error when creating tasks and team members

### DIFF
--- a/app/Filament/Resources/Projects/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/MembersRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Projects\RelationManagers;
 
+use App\Models\User;
 use Filament\Actions\AttachAction;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -23,6 +24,12 @@ class MembersRelationManager extends RelationManager
     {
         return $schema
             ->components([
+                \Filament\Forms\Components\Select::make('user_id')
+                    ->label('User')
+                    ->options(User::query()->pluck('name', 'id'))
+                    ->searchable()
+                    ->preload()
+                    ->required(),
                 \Filament\Forms\Components\Select::make('role')
                     ->options([
                         'Product Manager' => 'Product Manager',
@@ -32,6 +39,23 @@ class MembersRelationManager extends RelationManager
                     ->default('Developer')
                     ->required(),
             ]);
+    }
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['project_id'] = $this->ownerRecord->id;
+
+        return $data;
+    }
+
+    protected function getCreateFormAction(): CreateAction
+    {
+        return CreateAction::configure()
+            ->mutateFormDataUsing(function (array $data): array {
+                $data['project_id'] = $this->ownerRecord->id;
+
+                return $data;
+            });
     }
 
     public function table(Table $table): Table

--- a/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
@@ -20,6 +20,11 @@ class TasksRelationManager extends RelationManager
 
     protected static ?string $recordTitleAttribute = 'title';
 
+    protected function getCreatedByUserId(): int
+    {
+        return (int) auth()->id();
+    }
+
     public function form(Schema $schema): Schema
     {
         return $schema
@@ -52,6 +57,25 @@ class TasksRelationManager extends RelationManager
                     ->numeric()
                     ->default(0),
             ]);
+    }
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['project_id'] = $this->ownerRecord->id;
+        $data['created_by'] = $this->getCreatedByUserId();
+
+        return $data;
+    }
+
+    protected function getCreateFormAction(): CreateAction
+    {
+        return CreateAction::configure()
+            ->mutateFormDataUsing(function (array $data): array {
+                $data['project_id'] = $this->ownerRecord->id;
+                $data['created_by'] = $this->getCreatedByUserId();
+
+                return $data;
+            });
     }
 
     public function table(Table $table): Table


### PR DESCRIPTION
## Summary

Fixes the SQLSTATE[HY000]: General error: 1364 Field 'created_by' doesn't have a default value issue when creating new tasks and team members.

## Changes

### TasksRelationManager
- Added `mutateFormDataBeforeCreate()` method to automatically set `project_id` from the parent record and `created_by` from the authenticated user
- Added `getCreateFormAction()` to configure CreateAction with the same data injection

### MembersRelationManager
- Added `user_id` Select field to the form for selecting which user to add as a member
- Added `mutateFormDataBeforeCreate()` method to automatically set `project_id` from the parent record
- Added `getCreateFormAction()` to configure CreateAction with the project_id injection

## Testing

- Lint passes with `vendor/bin/pint --dirty`
- Basic test setup verified working