### PR TITLE
fix: split AMD64 and ARM64 build jobs without matrix strategy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,35 +65,17 @@ jobs:
             org.opencontainers.image.description=${{ steps.tag-description.outputs.description }}
 
   # -----------------------------------------------
-  # Job 2: Build Platforms in Parallel
+  # Job 2: Build AMD64 Platform
   # -----------------------------------------------
-  # Builds AMD64 and ARM64 images simultaneously
-  # Each platform builds on its native hardware
-  build:
-    name: Build ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+  build-amd64:
+    name: Build AMD64
+    runs-on: ubuntu-24.04
 
     needs: prepare
 
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # AMD64 build on native x86_64 runner
-          - name: AMD64
-            os: ubuntu-24.04
-            platform: linux/amd64
-            suffix: amd64
-
-          # ARM64 build on native ARM runner (no QEMU needed!)
-          - name: ARM64
-            os: ubuntu-24.04-arm
-            platform: linux/arm64
-            suffix: arm64
 
     steps:
       - name: Checkout repository
@@ -109,27 +91,74 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push ${{ matrix.name }} image
+      - name: Build and push AMD64 image
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           # Push platform-specific tag (e.g., ghcr.io/repo:1.0.0-amd64)
           tags: |
-            ${{ needs.prepare.outputs.image_base }}:${{ github.ref_name }}-${{ matrix.suffix }}
-            ${{ needs.prepare.outputs.image_base }}:${{ matrix.suffix }}
+            ${{ needs.prepare.outputs.image_base }}:${{ github.ref_name }}-amd64
+            ${{ needs.prepare.outputs.image_base }}:amd64
           labels: ${{ needs.prepare.outputs.version_labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Image digest
         run: |
-          echo "${{ matrix.name }} image digest: ${{ steps.build.outputs.digest }}"
+          echo "AMD64 image digest: ${{ steps.build.outputs.digest }}"
 
   # -----------------------------------------------
-  # Job 3: Merge Manifests
+  # Job 3: Build ARM64 Platform
+  # -----------------------------------------------
+  # ARM64 build on native ARM runner (no QEMU needed!)
+  build-arm64:
+    name: Build ARM64
+    runs-on: ubuntu-24.04-arm
+
+    needs: prepare
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ARM64 image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          # Push platform-specific tag (e.g., ghcr.io/repo:1.0.0-arm64)
+          tags: |
+            ${{ needs.prepare.outputs.image_base }}:${{ github.ref_name }}-arm64
+            ${{ needs.prepare.outputs.image_base }}:arm64
+          labels: ${{ needs.prepare.outputs.version_labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: |
+          echo "ARM64 image digest: ${{ steps.build.outputs.digest }}"
+
+  # -----------------------------------------------
+  # Job 4: Merge Manifests
   # -----------------------------------------------
   # Creates multi-architecture manifest after all
   # platform builds complete successfully
@@ -137,7 +166,7 @@ jobs:
     name: Create Multi-Arch Manifest
     runs-on: ubuntu-latest
 
-    needs: [prepare, build]
+    needs: [prepare, build-amd64, build-arm64]
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Remove matrix strategy from build jobs and create separate jobs for each platform
- Hardcode `runs-on` for each platform (ubuntu-24.04 for AMD64, ubuntu-24.04-arm for ARM64)
- Update manifest job dependencies to wait for both build jobs

## Problem
GitHub Actions doesn't support dynamic `runs-on` values from matrix strategy when using different runner types. The matrix approach works for platform tags but fails when trying to assign different runner types like `ubuntu-24.04` vs `ubuntu-24.04-arm`.

## Solution
Split the single build job with matrix into two separate jobs:
- `build-amd64`: Runs on `ubuntu-24.04`
- `build-arm64`: Runs on `ubuntu-24.04-arm`

Both jobs still run in parallel (depend only on `prepare` job) and the manifest job waits for both to complete.

## Changes
- Removed matrix strategy completely
- Created 2 separate build jobs with hardcoded runners
- Updated manifest job `needs` to depend on both build jobs
- Preserved existing logic for `latest` tag (only on default branch)