### PR TITLE
fix: always create latest tag on version pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -190,13 +190,11 @@ jobs:
               "${IMAGE_BASE}:${VERSION}-arm64"
           fi
 
-          # Create manifest for latest tag (only if on default branch)
-          if [ "${{ github.ref }}" == "$(git rev-parse --symbolic-full-name refs/remotes/origin/HEAD | sed 's@refs/remotes/origin/@@')" ]; then
-            docker buildx imagetools create \
-              --tag "${IMAGE_BASE}:latest" \
-              "${IMAGE_BASE}:${VERSION}-amd64" \
-              "${IMAGE_BASE}:${VERSION}-arm64"
-          fi
+          # Create manifest for latest tag (always created on version tags)
+          docker buildx imagetools create \
+            --tag "${IMAGE_BASE}:latest" \
+            "${IMAGE_BASE}:${VERSION}-amd64" \
+            "${IMAGE_BASE}:${VERSION}-arm64"
 
           echo "Multi-arch manifest created successfully!"
 


### PR DESCRIPTION
## Summary
- Fixed the `latest` tag not being created when publishing Docker images
- Removed conditional check that compared tag refs to branch names (impossible match)
- Now `latest` manifest is always created when version tags are pushed

## Root Cause
The previous condition compared refs/tags/v1.0.0 (tag ref) against development (branch name), which can never match.

## Test Plan
- [x] Workflow syntax is valid
- [ ] After merge, verify `latest` tag is created on next version push