### PR TITLE
fix: respect system environment variables in docker-entrypoint.sh

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -23,8 +23,11 @@ chmod -R 775 /var/www/html/storage /var/www/html/bootstrap/cache || true
 # 2. Database file doesn't exist yet
 # ===============================================
 
-# Get DB_CONNECTION from .env or use default
-DB_CONNECTION=$(grep -E "^DB_CONNECTION=" /var/www/html/.env 2>/dev/null | cut -d '=' -f2)
+# Get DB_CONNECTION with proper priority:
+# 1. System environment variable (Kubernetes ConfigMap/Secret, Docker -e flag)
+# 2. .env file (for local Docker compatibility)
+# 3. Empty (will default to 'sqlite' in logic below)
+DB_CONNECTION="${DB_CONNECTION:-$(grep -E '^DB_CONNECTION=' /var/www/html/.env 2>/dev/null | cut -d '=' -f2)}"
 
 if [ -z "$DB_CONNECTION" ] || [ "$DB_CONNECTION" = "sqlite" ]; then
     # Ensure database directory and file exist


### PR DESCRIPTION
## Summary
- Fix docker-entrypoint.sh to prioritize system environment variables over .env file values
- Enables proper Kubernetes ConfigMap/Secret support
- Maintains backward compatibility with existing Docker setups

## Issue
Fixes #42

## Changes
- Use POSIX parameter expansion `${VAR:-fallback}` to check system env first
- Fallback to .env file if system env not set (backward compatible)
- Update comments to explain the priority hierarchy

## Test plan
- [x] Code follows Laravel Boost guidelines
- [x] Run `vendor/bin/pint --dirty` to ensure formatting
- [x] Test with Kubernetes ConfigMap (DB_CONNECTION injected via env)
- [x] Test with Docker `-e` flag override
- [x] Test local Docker Compose (backward compatibility)

### Example Kubernetes ConfigMap
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: filament-pm-config
data:
  DB_CONNECTION: "mariadb"
  DB_HOST: "mariadb-service"
```

### Test Commands
```bash
# Test system env var takes precedence
docker run --rm -e DB_CONNECTION=mysql filament-pm:latest

# Test fallback to .env file
docker run --rm filament-pm:latest
```