### PR TITLE
fix: implement FilamentSocialiteUser interface to resolve Google SSO login error

### DIFF
--- a/app/Models/SocialiteUser.php
+++ b/app/Models/SocialiteUser.php
@@ -2,13 +2,16 @@
 
 namespace App\Models;
 
+use DutchCodingCompany\FilamentSocialite\Models\Contracts\FilamentSocialiteUser;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
 
-class SocialiteUser extends Model
+class SocialiteUser extends Model implements FilamentSocialiteUser
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
+    /** @use HasFactory<\Database\Factories\SocialiteUserFactory> */
     use HasFactory;
 
     protected $fillable = [
@@ -23,5 +26,37 @@ class SocialiteUser extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the authenticated user for this socialite account.
+     */
+    public function getUser(): Authenticatable
+    {
+        return $this->user;
+    }
+
+    /**
+     * Find a socialite user by provider and OAuth user ID.
+     */
+    public static function findForProvider(string $provider, SocialiteUserContract $oauthUser): ?self
+    {
+        return self::query()
+            ->where('provider', $provider)
+            ->where('provider_id', $oauthUser->getId())
+            ->first();
+    }
+
+    /**
+     * Create a new socialite user for a provider.
+     */
+    public static function createForProvider(string $provider, SocialiteUserContract $oauthUser, Authenticatable $user): self
+    {
+        return self::query()
+            ->create([
+                'user_id' => $user->getKey(),
+                'provider' => $provider,
+                'provider_id' => $oauthUser->getId(),
+            ]);
     }
 }

--- a/database/factories/SocialiteUserFactory.php
+++ b/database/factories/SocialiteUserFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\SocialiteUser>
+ */
+class SocialiteUserFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'provider' => fake()->randomElement(['google', 'github', 'facebook']),
+            'provider_id' => fake()->numerify('#########'),
+        ];
+    }
+}

--- a/tests/Feature/SocialiteLoginTest.php
+++ b/tests/Feature/SocialiteLoginTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SocialiteUser;
+use App\Models\User;
+use DutchCodingCompany\FilamentSocialite\Models\Contracts\FilamentSocialiteUser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
+use Tests\TestCase;
+
+class SocialiteLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_socialite_user_implements_filament_socialite_interface(): void
+    {
+        $socialiteUser = new SocialiteUser;
+
+        $this->assertInstanceOf(FilamentSocialiteUser::class, $socialiteUser);
+    }
+
+    public function test_get_user_returns_authenticatable_user(): void
+    {
+        $user = User::factory()->create();
+        $socialiteUser = SocialiteUser::factory()->create([
+            'user_id' => $user->id,
+            'provider' => 'google',
+            'provider_id' => '123456789',
+        ]);
+
+        $result = $socialiteUser->getUser();
+
+        $this->assertSame($user->id, $result->getKey());
+        $this->assertInstanceOf(\Illuminate\Contracts\Auth\Authenticatable::class, $result);
+    }
+
+    public function test_find_for_provider_finds_existing_socialite_user(): void
+    {
+        $user = User::factory()->create();
+        $socialiteUser = SocialiteUser::factory()->create([
+            'user_id' => $user->id,
+            'provider' => 'google',
+            'provider_id' => 'google-user-123',
+        ]);
+
+        $oauthUser = $this->createMockOAuthUser('google-user-123');
+
+        $result = SocialiteUser::findForProvider('google', $oauthUser);
+
+        $this->assertNotNull($result);
+        $this->assertSame($socialiteUser->id, $result->id);
+        $this->assertSame('google', $result->provider);
+        $this->assertSame('google-user-123', $result->provider_id);
+    }
+
+    public function test_find_for_provider_returns_null_when_not_found(): void
+    {
+        SocialiteUser::factory()->create([
+            'provider' => 'google',
+            'provider_id' => 'existing-user',
+        ]);
+
+        $oauthUser = $this->createMockOAuthUser('non-existent-user');
+
+        $result = SocialiteUser::findForProvider('google', $oauthUser);
+
+        $this->assertNull($result);
+    }
+
+    public function test_create_for_provider_creates_new_socialite_user(): void
+    {
+        $user = User::factory()->create();
+        $oauthUser = $this->createMockOAuthUser('new-google-user');
+
+        $result = SocialiteUser::createForProvider('google', $oauthUser, $user);
+
+        $this->assertDatabaseHas('socialite_users', [
+            'user_id' => $user->id,
+            'provider' => 'google',
+            'provider_id' => 'new-google-user',
+        ]);
+
+        $this->assertSame($user->id, $result->user_id);
+        $this->assertSame('google', $result->provider);
+        $this->assertSame('new-google-user', $result->provider_id);
+    }
+
+    public function test_find_or_create_integration(): void
+    {
+        $user = User::factory()->create();
+        $oauthUser = $this->createMockOAuthUser('integration-user');
+
+        // First call should create
+        $first = SocialiteUser::findForProvider('google', $oauthUser);
+        $this->assertNull($first);
+
+        $created = SocialiteUser::createForProvider('google', $oauthUser, $user);
+        $this->assertNotNull($created);
+
+        // Second call should find
+        $found = SocialiteUser::findForProvider('google', $oauthUser);
+        $this->assertNotNull($found);
+        $this->assertSame($created->id, $found->id);
+    }
+
+    /**
+     * Create a mock OAuth user for testing.
+     */
+    private function createMockOAuthUser(string $id): SocialiteUserContract
+    {
+        $mock = $this->createMock(SocialiteUserContract::class);
+        $mock->method('getId')->willReturn($id);
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `FilamentSocialiteUser` interface in `App\Models\SocialiteUser`
- Add `getUser()` method to return associated `Authenticatable` user
- Add `findForProvider()` method to find existing OAuth connections
- Add `createForProvider()` method to create new OAuth connections
- Create `SocialiteUserFactory` for testing
- Add comprehensive test suite with 6 tests

## Root Cause
The `App\Models\SocialiteUser` model did not implement the `DutchCodingCompany\FilamentSocialite\Models\Contracts\FilamentSocialiteUser` interface required by the `filament-socialite` package, causing a TypeError when users attempted to log in via Google SSO.

## Test plan
- [x] Created 6 comprehensive tests for the interface implementation
- [x] All tests pass (16 assertions)
- [x] Code formatted with Laravel Pint
- [ ] Manual testing: Verify Google SSO login works in production

Fixes #44