### PR TITLE
feat: Add Spatie Tags Support to Task, Document, and Project Models

### DIFF
--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Projects\Schemas;
 
+use Filament\Forms\Components\SpatieTagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
@@ -29,6 +30,9 @@ class ProjectForm
 
                         Textarea::make('description')
                             ->rows(3)
+                            ->columnSpanFull(),
+
+                        SpatieTagsInput::make('tags')
                             ->columnSpanFull(),
                     ])
                     ->columns(2),

--- a/app/Filament/Resources/Projects/Tables/ProjectsTable.php
+++ b/app/Filament/Resources/Projects/Tables/ProjectsTable.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Projects\Tables;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
+use Filament\Tables\Columns\SpatieTagsColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 
@@ -27,6 +28,9 @@ class ProjectsTable
                     ->label('Tasks')
                     ->counts('tasks')
                     ->sortable(),
+
+                SpatieTagsColumn::make('tags')
+                    ->toggleable(isToggledHiddenByDefault: false),
 
                 TextColumn::make('created_at')
                     ->dateTime()

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -11,10 +11,11 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\App;
 use Overtrue\LaravelVersionable\Versionable;
 use Overtrue\LaravelVersionable\VersionStrategy;
+use Spatie\Tags\HasTags;
 
 class Document extends Model
 {
-    use HasFactory, Versionable;
+    use HasFactory, HasTags, Versionable;
 
     protected $fillable = [
         'created_by',

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -8,10 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Tags\HasTags;
 
 class Project extends Model
 {
-    use HasFactory;
+    use HasFactory, HasTags;
 
     protected $fillable = [
         'owner_id',

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -8,10 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Spatie\Tags\HasTags;
 
 class Task extends Model
 {
-    use HasFactory;
+    use HasFactory, HasTags;
 
     protected $fillable = [
         'project_id',


### PR DESCRIPTION
## Summary
- Add `HasTags` trait to Task, Document, and Project models
- Add Spatie Tags UI components to Project resource (form and table)
- Fixes issue where tags appeared in forms but couldn't be saved/retrieved

## Changes
**Models:**
- `Task` - Added `HasTags` trait (UI was already in place)
- `Document` - Added `HasTags` trait (UI was already in place)
- `Project` - Added `HasTags` trait + added tags UI

**Project Resource:**
- Added `SpatieTagsInput` to ProjectForm
- Added `SpatieTagsColumn` to ProjectsTable

## Root Cause
The UI components (SpatieTagsInput/SpaciousTagsColumn) were already correctly implemented for Tasks and Documents, but the critical `HasTags` trait was missing from all models. Without this trait, tags could not be persisted to or retrieved from the database.

## Test plan
- [x] All models have tag methods verified (tags, attachTag, hasTag)
- [x] Code formatted with Pint
- [x] No new test failures introduced
- [ ] Manual testing: Create/edit tasks with tags
- [ ] Manual testing: Create/edit documents with tags
- [ ] Manual testing: Create/edit projects with tags
- [ ] Manual testing: Verify tags display in all list views