### PR TITLE
feat: add task due date feature (Issue #12)

### DIFF
--- a/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
@@ -10,6 +10,7 @@ use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
@@ -63,6 +64,10 @@ class TasksRelationManager extends RelationManager
                 \Filament\Forms\Components\TextInput::make('order')
                     ->numeric()
                     ->default(0),
+
+                DatePicker::make('due_date')
+                    ->label('Due Date')
+                    ->nullable(),
             ]);
     }
 
@@ -112,6 +117,14 @@ class TasksRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('order')
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
+
+                Tables\Columns\TextColumn::make('due_date')
+                    ->label('Due Date')
+                    ->date('M j, Y')
+                    ->sortable()
+                    ->color(fn ($record) => $record->due_date && (($record->due_date instanceof \Carbon\Carbon ? $record->due_date : \Carbon\Carbon::parse($record->due_date))->isPast()) && $record->status !== 'done' ? 'danger' : null)
+                    ->icon(fn ($record) => $record->due_date && (($record->due_date instanceof \Carbon\Carbon ? $record->due_date : \Carbon\Carbon::parse($record->due_date))->isPast()) && $record->status !== 'done' ? 'heroicon-o-exclamation-triangle' : null)
+                    ->toggleable(),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('status')

--- a/app/Filament/Resources/Tasks/Schemas/TaskForm.php
+++ b/app/Filament/Resources/Tasks/Schemas/TaskForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Tasks\Schemas;
 
+use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\MentionProvider;
 use Filament\Forms\Components\Select;
@@ -69,6 +70,10 @@ class TaskForm
                             ->numeric()
                             ->default(0)
                             ->minValue(0),
+
+                        DatePicker::make('due_date')
+                            ->label('Due Date')
+                            ->nullable(),
                     ])
                     ->columns(2)
                     ->columnSpanFull(),

--- a/app/Filament/Resources/Tasks/Tables/TasksTable.php
+++ b/app/Filament/Resources/Tasks/Tables/TasksTable.php
@@ -45,6 +45,13 @@ class TasksTable
                         'success' => 'done',
                     ]),
 
+                TextColumn::make('due_date')
+                    ->label('Due Date')
+                    ->date('M j, Y')
+                    ->sortable()
+                    ->color(fn ($record) => $record->due_date && (($record->due_date instanceof \Carbon\Carbon ? $record->due_date : \Carbon\Carbon::parse($record->due_date))->isPast()) && $record->status !== 'done' ? 'danger' : null)
+                    ->icon(fn ($record) => $record->due_date && (($record->due_date instanceof \Carbon\Carbon ? $record->due_date : \Carbon\Carbon::parse($record->due_date))->isPast()) && $record->status !== 'done' ? 'heroicon-o-exclamation-triangle' : null),
+
                 SpatieTagsColumn::make('tags')
                     ->toggleable(isToggledHiddenByDefault: false),
 

--- a/app/Filament/Widgets/KanbanWidget.php
+++ b/app/Filament/Widgets/KanbanWidget.php
@@ -54,6 +54,8 @@ class KanbanWidget extends Widget
                     'title' => $task->title,
                     'description' => $task->description,
                     'assigned_to' => $task->assignedTo?->name,
+                    'due_date' => $task->due_date ? ($task->due_date instanceof \Carbon\Carbon ? $task->due_date->toDateString() : $task->due_date) : null,
+                    'is_overdue' => $task->due_date && (($task->due_date instanceof \Carbon\Carbon ? $task->due_date : \Carbon\Carbon::parse($task->due_date))->isPast()) && $task->status !== 'done',
                 ])
                 ->values()
                 ->toArray();

--- a/resources/views/filament/widgets/kanban-board.blade.php
+++ b/resources/views/filament/widgets/kanban-board.blade.php
@@ -30,11 +30,21 @@
                                     {{ \Illuminate\Support\Str::limit($task['description'], 100) }}
                                 </p>
                             @endif
-                            @if($task['assigned_to'])
+                            @if($task['assigned_to'] || $task['due_date'])
                                 <div class="mt-2 flex items-center gap-2">
-                                    <span class="text-xs text-gray-500">
-                                        Assigned to: {{ $task['assigned_to'] }}
-                                    </span>
+                                    @if($task['assigned_to'])
+                                        <span class="text-xs text-gray-500">
+                                            Assigned to: {{ $task['assigned_to'] }}
+                                        </span>
+                                    @endif
+                                    @if($task['due_date'])
+                                        <span class="text-xs {{ $task['is_overdue'] ? 'text-danger-600 font-medium' : 'text-gray-500' }}">
+                                            Due: {{ \Carbon\Carbon::parse($task['due_date'])->format('M j') }}
+                                            @if($task['is_overdue'])
+                                                <span class="text-danger-600">!</span>
+                                            @endif
+                                        </span>
+                                    @endif
                                 </div>
                             @endif
                         </div>

--- a/tests/Filament/Widgets/KanbanWidgetTest.php
+++ b/tests/Filament/Widgets/KanbanWidgetTest.php
@@ -104,6 +104,8 @@ class KanbanWidgetTest extends TestCase
                     'title' => 'Test Task',
                     'description' => Task::first()->description,
                     'assigned_to' => $user->name,
+                    'due_date' => null,
+                    'is_overdue' => false,
                 ],
             ]);
     }


### PR DESCRIPTION
## Summary
This PR implements the Task Due Date feature as described in Issue #12.

### Changes Made
- **Migration**: The `due_date` column already existed in the database migration
- **TaskForm**: Added `DatePicker::make('due_date')` for setting task deadlines
- **TasksTable**: Added `due_date` column with:
  - Date formatting (M j, Y)
  - Overdue highlighting (red color + warning icon) for past due dates when status is not 'done'
  - Sortable functionality
- **TasksRelationManager**: Added `due_date` to both form and table with same overdue highlighting
- **KanbanWidget**: Added `due_date` and `is_overdue` fields to task data
- **Kanban Board View**: Display due dates with overdue indicators

### Acceptance Criteria Met
- Due date picker in Task form ✓
- Due date column in task tables ✓
- Overdue tasks highlighted ✓

### Testing
- Updated `KanbanWidgetTest` to include new due_date fields
- 4 of 5 Kanban widget tests pass (1 pre-existing authorization-related failure)