### PR TITLE
feat: add task priority field (Issue #11)

### DIFF
--- a/app/Enums/TaskPriority.php
+++ b/app/Enums/TaskPriority.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Enums;
+
+enum TaskPriority: string
+{
+    case LOW = 'low';
+    case MEDIUM = 'medium';
+    case HIGH = 'high';
+    case CRITICAL = 'critical';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::LOW => 'Low',
+            self::MEDIUM => 'Medium',
+            self::HIGH => 'High',
+            self::CRITICAL => 'Critical',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::LOW => 'gray',
+            self::MEDIUM => 'warning',
+            self::HIGH => 'orange',
+            self::CRITICAL => 'danger',
+        };
+    }
+
+    /**
+     * @return array<int, TaskPriority>
+     */
+    public static function ordered(): array
+    {
+        return [
+            self::LOW,
+            self::MEDIUM,
+            self::HIGH,
+            self::CRITICAL,
+        ];
+    }
+}

--- a/app/Filament/Resources/Tasks/Pages/ViewTask.php
+++ b/app/Filament/Resources/Tasks/Pages/ViewTask.php
@@ -42,6 +42,16 @@ class ViewTask extends ViewRecord
                                 'done' => 'success',
                                 default => 'gray',
                             }),
+
+                        TextEntry::make('priority')
+                            ->badge()
+                            ->color(fn (string $state): string => match ($state) {
+                                'low' => 'gray',
+                                'medium' => 'warning',
+                                'high' => 'orange',
+                                'critical' => 'danger',
+                                default => 'gray',
+                            }),
                         TextEntry::make('project.name'),
                         TextEntry::make('assignedTo.name')
                             ->label('Assigned To'),

--- a/app/Filament/Resources/Tasks/Schemas/TaskForm.php
+++ b/app/Filament/Resources/Tasks/Schemas/TaskForm.php
@@ -63,6 +63,16 @@ class TaskForm
                             ->default('todo')
                             ->required(),
 
+                        Select::make('priority')
+                            ->options([
+                                'low' => 'Low',
+                                'medium' => 'Medium',
+                                'high' => 'High',
+                                'critical' => 'Critical',
+                            ])
+                            ->default('low')
+                            ->required(),
+
                         SpatieTagsInput::make('tags')
                             ->columnSpanFull(),
 

--- a/app/Filament/Resources/Tasks/Tables/TasksTable.php
+++ b/app/Filament/Resources/Tasks/Tables/TasksTable.php
@@ -45,6 +45,15 @@ class TasksTable
                         'success' => 'done',
                     ]),
 
+                TextColumn::make('priority')
+                    ->badge()
+                    ->colors([
+                        'gray' => 'low',
+                        'warning' => 'medium',
+                        'orange' => 'high',
+                        'danger' => 'critical',
+                    ]),
+
                 TextColumn::make('due_date')
                     ->label('Due Date')
                     ->date('M j, Y')
@@ -71,6 +80,14 @@ class TasksTable
                         'in_progress' => 'In Progress',
                         'review' => 'Review',
                         'done' => 'Done',
+                    ]),
+
+                SelectFilter::make('priority')
+                    ->options([
+                        'low' => 'Low',
+                        'medium' => 'Medium',
+                        'high' => 'High',
+                        'critical' => 'Critical',
                     ]),
 
                 SelectFilter::make('project')

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -21,9 +21,17 @@ class Task extends Model
         'title',
         'description',
         'status',
+        'priority',
         'order',
         'due_date',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'priority' => \App\Enums\TaskPriority::class,
+        ];
+    }
 
     public function project(): BelongsTo
     {

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -20,6 +20,7 @@ class TaskFactory extends Factory
             'title' => fake()->sentence(),
             'description' => fake()->paragraph(),
             'status' => fake()->randomElement(['todo', 'in_progress', 'review', 'done']),
+            'priority' => fake()->randomElement(['low', 'medium', 'high', 'critical']),
             'order' => fake()->numberBetween(0, 100),
             'due_date' => fake()->optional()->date(),
         ];

--- a/database/migrations/2026_01_26_191757_add_priority_to_tasks_table.php
+++ b/database/migrations/2026_01_26_191757_add_priority_to_tasks_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->enum('priority', ['low', 'medium', 'high', 'critical'])->default('low')->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('priority');
+        });
+    }
+};

--- a/tests/Unit/Enums/TaskPriorityTest.php
+++ b/tests/Unit/Enums/TaskPriorityTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\TaskPriority;
+use PHPUnit\Framework\TestCase;
+
+class TaskPriorityTest extends TestCase
+{
+    public function test_default_priorities_exist()
+    {
+        $this->assertEquals('low', TaskPriority::LOW->value);
+        $this->assertEquals('medium', TaskPriority::MEDIUM->value);
+        $this->assertEquals('high', TaskPriority::HIGH->value);
+        $this->assertEquals('critical', TaskPriority::CRITICAL->value);
+    }
+
+    public function test_get_label_returns_translated_label()
+    {
+        $this->assertEquals('Low', TaskPriority::LOW->getLabel());
+        $this->assertEquals('Medium', TaskPriority::MEDIUM->getLabel());
+        $this->assertEquals('High', TaskPriority::HIGH->getLabel());
+        $this->assertEquals('Critical', TaskPriority::CRITICAL->getLabel());
+    }
+
+    public function test_get_color_returns_color_for_priority()
+    {
+        $this->assertEquals('gray', TaskPriority::LOW->getColor());
+        $this->assertEquals('warning', TaskPriority::MEDIUM->getColor());
+        $this->assertEquals('orange', TaskPriority::HIGH->getColor());
+        $this->assertEquals('danger', TaskPriority::CRITICAL->getColor());
+    }
+
+    public function test_get_all_priorities_ordered()
+    {
+        $ordered = TaskPriority::ordered();
+        $this->assertEquals([
+            TaskPriority::LOW,
+            TaskPriority::MEDIUM,
+            TaskPriority::HIGH,
+            TaskPriority::CRITICAL,
+        ], $ordered);
+    }
+
+    public function test_from_value_creates_enum()
+    {
+        $priority = TaskPriority::from('low');
+        $this->assertEquals(TaskPriority::LOW, $priority);
+    }
+
+    public function test_try_from_value_returns_enum_or_null()
+    {
+        $priority = TaskPriority::tryFrom('low');
+        $this->assertEquals(TaskPriority::LOW, $priority);
+
+        $invalid = TaskPriority::tryFrom('invalid_priority');
+        $this->assertNull($invalid);
+    }
+}


### PR DESCRIPTION
## Summary
Add priority field to tasks with 4 levels: Low, Medium, High, Critical

## Changes
- **Enum**: Create `TaskPriority` enum with `getLabel()` and `getColor()` methods
- **Database**: Add `priority` column to tasks table with default `low`
- **Form**: Add priority Select dropdown to TaskForm schema
- **Table**: Add priority column with colored badges to TasksTable
- **Filter**: Add priority filter to TasksTable filters
- **View**: Add priority badge to ViewTask page
- **Factory**: Update TaskFactory with priority field
- **Tests**: Add TaskPriority enum unit tests

## Color Mapping
| Priority | Color |
|----------|-------|
| Low | gray |
| Medium | warning (yellow) |
| High | orange |
| Critical | danger (red) |

## Test Plan
- [x] TaskPriority enum tests pass
- [x] Task model tests pass