### PR TITLE
fix: responsive column layout for Filament v4 forms (Issue #51)

### DIFF
--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -16,6 +16,10 @@ class ProjectForm
         return $schema
             ->components([
                 Section::make()
+                    ->columns([
+                        'sm' => 1,
+                        'lg' => 2,
+                    ])
                     ->schema([
                         TextInput::make('name')
                             ->required()
@@ -34,8 +38,7 @@ class ProjectForm
 
                         SpatieTagsInput::make('tags')
                             ->columnSpanFull(),
-                    ])
-                    ->columns(2),
+                    ]),
             ]);
     }
 }

--- a/app/Filament/Resources/Tasks/Schemas/TaskForm.php
+++ b/app/Filament/Resources/Tasks/Schemas/TaskForm.php
@@ -18,6 +18,10 @@ class TaskForm
         return $schema
             ->components([
                 Section::make()
+                    ->columns([
+                        'sm' => 1,
+                        'lg' => 2,
+                    ])
                     ->schema([
                         Select::make('project_id')
                             ->relationship('project', 'name')
@@ -85,7 +89,6 @@ class TaskForm
                             ->label('Due Date')
                             ->nullable(),
                     ])
-                    ->columns(2)
                     ->columnSpanFull(),
             ]);
     }

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -2,8 +2,8 @@
 
 namespace App\Filament\Resources\Users\Schemas;
 
-use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Spatie\Permission\Models\Role;
@@ -15,6 +15,10 @@ class UserForm
         return $schema
             ->components([
                 Section::make()
+                    ->columns([
+                        'sm' => 1,
+                        'lg' => 2,
+                    ])
                     ->schema([
                         TextInput::make('name')
                             ->required()
@@ -42,8 +46,7 @@ class UserForm
                             ->searchable()
                             ->options(Role::query()->pluck('name', 'id'))
                             ->required(),
-                    ])
-                    ->columns(2),
+                    ]),
             ]);
     }
 }


### PR DESCRIPTION
## Summary

Fix inconsistent and non-responsive form layouts across Filament v4 resources. The issue was that three out of four forms used fixed `columns(2)` which doesn't adapt to different screen sizes.

## Changes

Updated the following form schemas to use responsive column breakpoints:

- **TaskForm**: Changed `columns(2)` to `columns(['sm' => 1, 'lg' => 2])`
- **ProjectForm**: Changed `columns(2)` to `columns(['sm' => 1, 'lg' => 2])`
- **UserForm**: Changed `columns(2)` to `columns(['sm' => 1, 'lg' => 2])`

## Pattern Followed

This follows the existing pattern used in `DocumentForm.php` which already implements responsive layouts:

```php
Section::make()
    ->columns([
        'sm' => 1,  // 1 column on mobile
        'lg' => 2,  // 2 columns on desktop
    ])
```

## Result

Forms now render properly on all screen sizes:
- Mobile: Single column layout
- Desktop: Two-column layout

## Test plan

- [ ] Verify Task create/edit forms are responsive
- [ ] Verify Project create/edit forms are responsive
- [ ] Verify User create/edit forms are responsive