### PR TITLE
fix: remove pre-package-uninstall composer hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,9 +74,6 @@
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --graceful --ansi"
-        ],
-        "pre-package-uninstall": [
-            "Illuminate\\Foundation\\ComposerScripts::prePackageUninstall"
         ]
     },
     "extra": {


### PR DESCRIPTION
## Summary

- Removed the `pre-package-uninstall` composer hook from composer.json
- Fixes composer install failures in Laravel 12 applications

## Problem

The `pre-package-uninstall` hook tries to bootstrap Laravel during `composer install`, but Laravel can't boot because classes from packages being installed (like `FilamentSocialitePlugin`) aren't autoloaded yet.

```
> pre-package-uninstall: Illuminate\Foundation\ComposerScripts::prePackageUninstall
Script Illuminate\Foundation\ComposerScripts::prePackageUninstall handling the pre-package-uninstall event terminated with an exception

In ProcessDriver.php line 46:
Concurrent process failed with exit code [1].
```

## Root Cause

Laravel 12 introduced a new `prePackageUninstall` hook that uses ProcessDriver to dispatch events in a separate process. The hook runs before packages are fully installed, creating a chicken-and-egg problem where:
1. The script needs Laravel to be bootstrapped
2. Laravel can't bootstrap because packages aren't fully installed yet
3. Classes from packages being installed aren't autoloaded

## Solution

Removed the `pre-package-uninstall` hook from composer.json. This hook is only useful for dispatching events before packages are uninstalled in dev mode, which most applications don't need.

## Test Plan

- [x] `ddev composer install` completes successfully
- [x] All packages are installed correctly
- [x] No errors during package discovery