### PR TITLE
fix: properly set created_by when creating tasks from project relation manager (Issue #61)

### DIFF
--- a/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/TasksRelationManager.php
@@ -12,6 +12,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\SpatieTagsInput;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
@@ -68,6 +69,18 @@ class TasksRelationManager extends RelationManager
                 DatePicker::make('due_date')
                     ->label('Due Date')
                     ->nullable(),
+
+                Select::make('priority')
+                    ->options([
+                        'low' => 'Low',
+                        'medium' => 'Medium',
+                        'high' => 'High',
+                        'critical' => 'Critical',
+                    ])
+                    ->default('low')
+                    ->required(),
+
+                SpatieTagsInput::make('tags'),
             ]);
     }
 
@@ -204,7 +217,7 @@ class TasksRelationManager extends RelationManager
                 ]),
             ])
             ->toolbarActions([
-                CreateAction::make(),
+                $this->getCreateFormAction(),
             ])
             ->defaultSort('order', 'asc');
     }


### PR DESCRIPTION
## Summary

Fixes the issue where `created_by` was not being set when creating tasks from the project relation manager in Filament.

## Changes

- **TasksRelationManager.php**: Use `$this->getCreateFormAction()` instead of `CreateAction::make()` in toolbar actions to ensure the `mutateFormDataUsing` callback runs and sets `created_by`
- Add missing `priority` and `tags` fields to the TasksRelationManager form to match the main Task create form

## Root Cause

When using `CreateAction::make()` directly in `toolbarActions()`, the customized `getCreateFormAction()` method (which contains `mutateFormDataUsing` to set `created_by`) was being bypassed.

## Test plan

- [ ] Create a task from a project's relation manager
- [ ] Verify `created_by` is properly set in the database