### PR TITLE
feat: add Pending Invitations relation manager display

### DIFF
--- a/app/Filament/Resources/Projects/ProjectResource.php
+++ b/app/Filament/Resources/Projects/ProjectResource.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\Projects\Pages\CreateProject;
 use App\Filament\Resources\Projects\Pages\EditProject;
 use App\Filament\Resources\Projects\Pages\ListProjects;
 use App\Filament\Resources\Projects\Pages\ProjectKanban;
+use App\Filament\Resources\Projects\RelationManagers\InvitationsRelationManager;
 use App\Filament\Resources\Projects\RelationManagers\MembersRelationManager;
 use App\Filament\Resources\Projects\RelationManagers\TasksRelationManager;
 use App\Filament\Resources\Projects\Schemas\ProjectForm;
@@ -37,6 +38,7 @@ class ProjectResource extends Resource
     {
         return [
             MembersRelationManager::class,
+            InvitationsRelationManager::class,
             TasksRelationManager::class,
         ];
     }

--- a/app/Filament/Resources/Projects/RelationManagers/InvitationsRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/InvitationsRelationManager.php
@@ -2,8 +2,8 @@
 
 namespace App\Filament\Resources\Projects\RelationManagers;
 
-use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
 
@@ -15,9 +15,9 @@ class InvitationsRelationManager extends RelationManager
 
     protected static ?string $recordTitleAttribute = 'email';
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form
+        return $schema
             ->schema([
                 //
             ]);

--- a/app/Filament/Resources/Projects/RelationManagers/InvitationsRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/InvitationsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Projects\RelationManagers;
 
+use Filament\Actions\DeleteAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
@@ -71,7 +72,7 @@ class InvitationsRelationManager extends RelationManager
                 //
             ])
             ->recordActions([
-                Tables\Actions\DeleteAction::make()
+                DeleteAction::make()
                     ->label('Cancel Invitation')
                     ->successNotificationTitle('Invitation cancelled successfully'),
             ])

--- a/app/Filament/Resources/Projects/RelationManagers/InvitationsRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/InvitationsRelationManager.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Filament\Resources\Projects\RelationManagers;
+
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class InvitationsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'invitations';
+
+    protected static ?string $title = 'Pending Invitations';
+
+    protected static ?string $recordTitleAttribute = 'email';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                //
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn ($query) => $query->pending())
+            ->columns([
+                Tables\Columns\TextColumn::make('email')
+                    ->label('Email')
+                    ->sortable()
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('role')
+                    ->label('Role')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'Product Manager' => 'danger',
+                        'Developer' => 'warning',
+                        'Viewer' => 'success',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->color('warning')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('inviter.name')
+                    ->label('Invited By')
+                    ->sortable()
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('expires_at')
+                    ->label('Expires')
+                    ->dateTime()
+                    ->sortable()
+                    ->color(fn ($record) => $record->isExpired() ? 'danger' : null)
+                    ->description(fn ($record): string => $record->isExpired() ? 'Expired' : 'Pending'),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Sent')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                Tables\Actions\DeleteAction::make()
+                    ->label('Cancel Invitation')
+                    ->successNotificationTitle('Invitation cancelled successfully'),
+            ])
+            ->emptyStateHeading('No pending invitations')
+            ->emptyStateDescription('Send invitations via email to add new team members to this project.');
+    }
+}

--- a/app/Filament/Resources/Projects/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/Projects/RelationManagers/MembersRelationManager.php
@@ -105,8 +105,8 @@ class MembersRelationManager extends RelationManager
                         $this->ownerRecord->members()->select('user_id')
                     )
                     )
-                    ->form(fn (AttachAction $action) => [
-                        $action->getRecordSelectComponent()
+                    ->schema(fn (AttachAction $action): array => [
+                        $action->getRecordSelect()
                             ->label('Team Member')
                             ->required()
                             ->searchable()


### PR DESCRIPTION
## Summary
- Add new `InvitationsRelationManager` to display pending project invitations
- Show invited email, role, status, inviter, expiry date, and sent date
- Add ability to cancel pending invitations via delete action
- Filter to show only pending (non-expired) invitations

## Changes
- Created `InvitationsRelationManager` with proper Filament v4 API
- Registered relation manager in `ProjectResource`
- Used `modifyQueryUsing()` with `pending()` scope for filtering
- Added cancellation action for invitations

## Test plan
- [x] Navigate to Project edit page
- [x] Verify "Pending Invitations" tab appears
- [x] Verify pending invitations are displayed with correct columns
- [x] Verify cancel action removes invitation
- [x] Verify expired invitations are not shown

## Additional Fixes
This PR also includes fixes from `fix/attach-action-filament-v4` branch:
- Fixed `AttachAction` API compatibility (`getRecordSelectComponent()` → `getRecordSelect()`, `form()` → `schema()`)